### PR TITLE
Changed "Line" to "line" to make tagbar jump to source code

### DIFF
--- a/src/main/scala/sctags/Tag.scala
+++ b/src/main/scala/sctags/Tag.scala
@@ -22,7 +22,7 @@ case class Tag(val name: String, pos: TagPosition, fields: Product2[String, Stri
     if (fields.isEmpty) {
       ""
     } else {
-      (fields ++ Seq("Line"->pos.line.toString)).
+      (fields ++ Seq("line"->pos.line.toString)).
         map(fieldString).mkString(";\"\t", "\t", "")
     }
   override def toString =


### PR DESCRIPTION
Tagbar won't work when there is "Line" in the tags, it does however with "line"

See:
https://github.com/majutsushi/tagbar/blob/master/autoload/tagbar.vim#L1201