### PR TITLE
Follow symlinks until final destination

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ assemblyOption in assembly := (assemblyOption in assembly).value.copy(prependShe
     """         exit 1;""",
     """      fi""",
     """      if [[ -L "$SCALA_BIN" ]]; then""",
-    """        SCALA_BIN=$(readlink $SCALA_BIN)""",
+    """        SCALA_BIN=$(readlink -f $SCALA_BIN)""",
     """      fi""",
     """      SCALA_HOME=$(dirname "$SCALA_BIN")/..""",
     """      SCALA_LIB="$SCALA_HOME/lib"""",


### PR DESCRIPTION
On some systems (like ubuntu 18.04), readlink does not directly send you to the correct destination, but to alternatives. See this example

```
> which scala
/usr/bin/scala
> readlink $(which scala)
/etc/alternatives/scala
```

Readlink has -f option, which follows links recursively. That way it will always find the correct destination.